### PR TITLE
BugFix: prevHandler & nextHandler don't check if new currentIndex is valid

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,16 +4,13 @@ import styles from './styles.module.css';
 import { StepStates, ProgressStep, StepProgressProps, ReducerAction } from './models';
 
 function stepsReducer(steps: ProgressStep[], action: ReducerAction): ProgressStep[] {
-
-  return steps.map(function(step, i) {
-
+  return steps.map(function (step, i) {
     if (i < action.payload.index) {
       return { ...step, state: StepStates.COMPLETED };
     } else if (i === action.payload.index) {
       return { ...step, state: action.payload.state };
     } else {
-      step.state = StepStates.NOT_STARTED;
-      return step;
+      return { ...step, state: StepStates.NOT_STARTED };
     }
   });
 }
@@ -41,6 +38,10 @@ function StepProgressBar(props: StepProgressProps): JSX.Element {
   }, []);
 
   function nextHandler(): void {
+    if (currentIndex === steps.length - 1) {
+      return;
+    }
+
     let isStateValid = true;
     const stepValidator = state[currentIndex].validator;
 
@@ -61,6 +62,10 @@ function StepProgressBar(props: StepProgressProps): JSX.Element {
   }
 
   function prevHandler(): void {
+    if (currentIndex === 0) {
+      return;
+    }
+
     dispatch({
       type: 'previous',
       payload: {


### PR DESCRIPTION
Currently the previous & next buttons can have their "disabled" class removed and be clicked which will result in an invalid index error. This adds checks to prevHandler and nextHandler to fix this